### PR TITLE
Add a persistent object database that can hold code and properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+node_modules/

--- a/server/database.js
+++ b/server/database.js
@@ -1,0 +1,101 @@
+import fs from 'node:fs'
+
+/**
+ * Database objects are special because:
+ *  - They need to be reliably serializable in order to survive the checkpoint/restore of the database
+ *  - They need to store functions that survive serialization
+ *  - Those stored functions need to reference other database objects after deserialization
+ */
+
+class DatabaseObject {
+    // Right now this class is just a convenient way to keep track of which objects are DB objects, but we'll probably
+    // want to add quality-of-life stuff that makes it easy to work with them later.
+    constructor(data) {
+        this.id = ulid()
+        Object.assign(this, data)
+    }
+}
+
+export function createObject(data) {
+    const obj = new DatabaseObject(data)
+    db[obj.id] = obj
+    return obj
+}
+
+export function deleteObject(id) {
+    delete db[id]
+}
+
+const dbDataFile = process.argv[2]
+
+export function loadDatabase() {
+    console.log(`Loading database...`)
+    const db = JSON.parse(fs.readFileSync(dbDataFile))
+    restoreDbObjects(db)
+    // Setup shortcut refs for important objects
+    for (const [name, id] of Object.entries(db.refs ?? {})) {
+        global[`$${name}`] = db[id]
+    }
+    global.db = db
+    console.log(`Database loaded.  Created ${Object.keys(db).length - 1} objects.  Added ${Object.keys(db.refs).length} refs.`)
+}
+
+export function dumpDatabase() {
+    console.log(`Dumping database...`)
+    const serializedDB = JSON.stringify(db, transformDbObjects, 2)
+    fs.writeFileSync(dbDataFile, serializedDB)
+}
+
+function transformDbObjects(key, value) {
+    switch (typeof value) {
+        case 'function':
+            if (value.toString().includes('[native code]'))
+                throw new Error(`Can't serialize native function code for key ${key} in ${this}: ${value.toString()}`)
+            else
+                return { dbSerializerTransform: 'function', code: value.toString() }
+        case 'object':
+            if (value.constructor.name === 'DatabaseObject')
+                if (this === db)
+                    return { dbSerializerTransform: 'dbObject', ...value } // top-level DB object, should be fully serialized
+                else
+                    return { dbSerializerTransform: 'ref', id: value.id } // DB object referenced somewhere else, store as a ref
+            else
+                return value
+        default:
+            return value
+    }
+}
+
+function restoreDbObjects(db) {
+    for (const [id, data] of Object.entries(db)) {
+        // Everything but the 'refs' field should be a dbObject
+        if (data.dbSerializerTransform === 'dbObject') {
+            // Transform function code back to functions
+            for (const [field, value] of Object.entries(data)) {
+                if (value.dbSerializerTransform === 'function')
+                    data[field] = new Function(`return ${value.code}`)()
+            }
+            delete data.dbSerializerTransform
+            db[id] = new DatabaseObject(data)
+        }
+    }
+    restoreRefs(db, db)
+}
+
+function restoreRefs(node, db) {
+    if (typeof node !== 'object') return
+    if (Array.isArray(node)) {
+        for (const entry of node) {
+            restoreRefs(entry, db)
+        }
+        return
+    }
+    for (const [key, value] of Object.entries(node)) {
+        if (value.dbSerializerTransform === 'ref') {
+            node[key] = db[value.id]
+            return
+        } else {
+            restoreRefs(value, db)
+        }
+    }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,7 @@
 import { Server } from './websocketServer.js'
+import { createPrimitives } from './primitives.js'
+
+createPrimitives()
+loadDatabase()
 
 global.server = new Server(6969)

--- a/server/parser.js
+++ b/server/parser.js
@@ -5,7 +5,7 @@ export function handleInput(connection, message) {
         try {
             connection.announce(`${ eval?.(text.substring(1)) }`)
         } catch (error) {
-            connection.announce(error.toString())
+            connection.announce(error.stack)
         }
     } else {
         global.server.announceAll(`[${connection.id}] ${message}`)

--- a/server/primitives.js
+++ b/server/primitives.js
@@ -1,0 +1,10 @@
+import { createObject, deleteObject, dumpDatabase, loadDatabase} from './database.js'
+import { ulid } from 'ulid'
+
+export function createPrimitives() {
+    global.createObject = createObject
+    global.deleteObject = deleteObject
+    global.dumpDatabase = dumpDatabase
+    global.loadDatabase = loadDatabase
+    global.ulid = ulid
+}

--- a/server/test.db
+++ b/server/test.db
@@ -1,0 +1,25 @@
+{
+  "refs": {
+    "test": "01JNAT8V0WVB02DXGXZ3KPYD0V",
+    "user": "01JND0MJEHG5TJZN5P9DWYH23V"
+  },
+  "01JNAT8V0WVB02DXGXZ3KPYD0V": {
+    "dbSerializerTransform": "dbObject",
+    "id": "01JNAT8V0WVB02DXGXZ3KPYD0V",
+    "name": "testObj",
+    "awesomeFunc": {
+      "dbSerializerTransform": "function",
+      "code": "async () => 1"
+    },
+    "coolBool": false,
+    "selfRef": {
+      "dbSerializerTransform": "ref",
+      "id": "01JNAT8V0WVB02DXGXZ3KPYD0V"
+    }
+  },
+  "01JND0MJEHG5TJZN5P9DWYH23V": {
+    "dbSerializerTransform": "dbObject",
+    "id": "01JND0MJEHG5TJZN5P9DWYH23V",
+    "name": "Generic User"
+  }
+}


### PR DESCRIPTION
This PR adds the ability to create new database objects and save them to a JSON file.  Database objects are serialized such that functions and references to other DB object are transformed into special data container objects that can be deserialized back to their original form when we load the database.

The database objects are like any other Javascript objects in that they can have functions and properties, but because of their serialization limitations you would never want their properties to hold references to anything except types that can be serialized properly (other database objects, or arrays or maps that only contain references to other arrays, maps, and database objects).  In this context "map" is shorthand for a plain javascript object, not an instance of Map (since the Map type serializes as an empty object via JSON.stringify).

As far as the ability to write code in a straightforward way goes, I think this all works pretty well.  
```
const mel = createObject({ name: 'Melville' })
mel.add = function (x, y) { return x + y }
const seven = mel.add(3, 4)
const someObj = db['01JN99MY6H765G3JFZ0J6CR78Y'] // reference a DB object directly via its ID
db.refs['mel'] = mel.id // db.refs holds IDs of named DB objects.  This will become $mel when loading the DB
$mel = db[db.refs.mel] // This is how the named DB object ref is created
const dan = createObject({ name: "Daniel", friend: $mel }) // This is safe to do because friend is a ref to a DB object
const twelve = dan.friend.add(7, 5)
```

Note that if you define functions on DB objects as shown above (an assignment using the "function (args) { ... }" syntax) when you say 'this' in the function it will automatically refer to the DB object the code lives on, which is nice.  That does NOT work for arrow functions:
```
dbObj.accumulate = (x) => {   this.total = (this.total ?? 0) + x } // "this" will refer to the global context here!  Probably not what you want
```
You can still use arrow functions in code, and they will capture the scope of the block they're in.  And you can pass them around or do whatever you'd normally do with them.

It's also unfortunate that if you call `.bind(whateverThisShouldBe)` to set "this", the new function you get back is "native code" which this implementation won't be able to serialize.  But you can still do `myFunc.call(whateverThisShouldBe, ...args)` when you want to set "this" explicitly.  I'm not sure if we'll be able to get other useful vars like "player" into the execution context.  I haven't run into any obvious way to do that yet, but it might exist.