### PR TITLE
Persistent Tasks

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -198,11 +198,16 @@ function restoreTasks(db) {
     if (!db.tasks) db.tasks = {}
     for (const [id, taskDef] of Object.entries(db.tasks)) {
         // We expect the tasks to be in insertion order, which is chronological
-        const { func: { code }, runAt, args } = taskDef
+        const { func: { code }, runAt, interval, args } = taskDef
         const func = new Function(`return ${code}`)()
-        db.tasks[id].timeoutInfo = setTimeout(() => {
-            func(...args)
-            clearTask(id)
-        }, runAt - Date.now())
+        if (runAt) {
+            db.tasks[id].timeoutInfo = setTimeout(() => {
+                func(...args)
+                clearTask(id)
+            }, runAt - Date.now())
+        } else if (interval) {
+            db.tasks[id].timeoutInfo = setInterval(func, interval, ...args)
+            // These will only go away when something else calls clearTask
+        }
     }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -5,3 +5,7 @@ createPrimitives()
 loadDatabase()
 
 global.server = new Server(6969)
+
+// Prevent server death for unhandled sync or async errors
+process.on('uncaughtException', (err) => console.error('Unhandled exception:', err))
+process.on('unhandledRejection', (reason, promise) => console.error('Unhandled Rejection at:', promise, 'reason:', reason))

--- a/server/primitives.js
+++ b/server/primitives.js
@@ -1,5 +1,5 @@
 import { ancestors, changeParent, children, createObject, deleteObject, descendants, dumpDatabase, leaves, loadDatabase, parent } from './database.js'
-import { clearTask, scheduleTask, tasks } from './tasks.js'
+import { clearTask, scheduleTask, scheduleTaskInterval, tasks } from './tasks.js'
 import { ulid } from 'ulid'
 
 export function createPrimitives() {
@@ -15,6 +15,7 @@ export function createPrimitives() {
     global.loadDatabase = loadDatabase
     global.parent = parent
     global.scheduleTask = scheduleTask
+    global.scheduleTaskInterval = scheduleTaskInterval
     global.tasks = tasks
     global.ulid = ulid
 }

--- a/server/primitives.js
+++ b/server/primitives.js
@@ -1,10 +1,12 @@
 import { ancestors, changeParent, children, createObject, deleteObject, descendants, dumpDatabase, leaves, loadDatabase, parent } from './database.js'
+import { clearTask, scheduleTask, tasks } from './tasks.js'
 import { ulid } from 'ulid'
 
 export function createPrimitives() {
     global.ancestors = ancestors
     global.changeParent = changeParent
     global.children = children
+    global.clearTask = clearTask
     global.createObject = createObject
     global.deleteObject = deleteObject
     global.descendants = descendants
@@ -12,5 +14,7 @@ export function createPrimitives() {
     global.leaves = leaves
     global.loadDatabase = loadDatabase
     global.parent = parent
+    global.scheduleTask = scheduleTask
+    global.tasks = tasks
     global.ulid = ulid
 }

--- a/server/tasks.js
+++ b/server/tasks.js
@@ -13,6 +13,17 @@ export function scheduleTask(func, timeout, ...args) {
     return id
 }
 
+export function scheduleTaskInterval(func, timeout, ...args) {
+    if (typeof func !== 'function')
+        throw new Error('Task to schedule must be a function')
+    if (func.toString().includes('[native code]'))
+        throw new Error('Task function contains native code.  Scheduled tasks must be serializable')
+    const id = ulid()
+    const timeoutInfo = setInterval(func, timeout, ...args)
+    db.tasks[id] = { id, func, timeoutInfo, interval: timeout, args }
+    return id
+}
+
 export function clearTask(taskId) {
     const { timeoutInfo } = db.tasks[taskId]
     if (timeoutInfo) {

--- a/server/tasks.js
+++ b/server/tasks.js
@@ -1,0 +1,29 @@
+
+export function scheduleTask(func, timeout, ...args) {
+    if (typeof func !== 'function')
+        throw new Error('Task to schedule must be a function')
+    if (func.toString().includes('[native code]'))
+        throw new Error('Task function contains native code.  Scheduled tasks must be serializable')
+    const id = ulid()
+    const timeoutInfo = setTimeout(() => {
+        func(...args)
+        clearTask(id)
+    }, timeout)
+    db.tasks[id] = { id, func, timeoutInfo, runAt: Date.now() + timeout, args }
+    return id
+}
+
+export function clearTask(taskId) {
+    const { timeoutInfo } = db.tasks[taskId]
+    if (timeoutInfo) {
+        clearTimeout(timeoutInfo)
+        delete db.tasks[taskId]
+        return true
+    } else {
+        return false
+    }
+}
+
+export function tasks(user) {
+    return Object.values(db.tasks)
+}

--- a/server/tasks.js
+++ b/server/tasks.js
@@ -1,13 +1,13 @@
 
 export function scheduleTask(func, timeout, ...args) {
     if (typeof func !== 'function')
-        throw new Error('Task to schedule must be a function')
+        throw new TypeError('Task to schedule must be a function')
     if (func.toString().includes('[native code]'))
         throw new Error('Task function contains native code.  Scheduled tasks must be serializable')
     const id = ulid()
     const timeoutInfo = setTimeout(() => {
-        func(...args)
         clearTask(id)
+        func(...args)
     }, timeout)
     db.tasks[id] = { id, func, timeoutInfo, runAt: Date.now() + timeout, args }
     return id
@@ -15,7 +15,7 @@ export function scheduleTask(func, timeout, ...args) {
 
 export function scheduleTaskInterval(func, timeout, ...args) {
     if (typeof func !== 'function')
-        throw new Error('Task to schedule must be a function')
+        throw new TypeError('Task to schedule must be a function')
     if (func.toString().includes('[native code]'))
         throw new Error('Task function contains native code.  Scheduled tasks must be serializable')
     const id = ulid()
@@ -35,6 +35,6 @@ export function clearTask(taskId) {
     }
 }
 
-export function tasks(user) {
+export function tasks() {
     return Object.values(db.tasks)
 }

--- a/server/test.db
+++ b/server/test.db
@@ -25,7 +25,7 @@
     "name": "Generic User",
     "tell": {
       "dbSerializerTransform": "function",
-      "code": "function (text) { server.connectionFor(this).announce(text) }"
+      "code": "function (text) { server.connectionFor(this)?.announce(text) }"
     },
     "command_say": {
       "dbSerializerTransform": "function",
@@ -48,6 +48,10 @@
       "dbSerializerTransform": "function",
       "code": "function (text) { try { this.tell(`${ eval?.(text) }`) } catch (error) { this.tell(error.stack) } }"
     },
+    "command_tasks": {
+      "dbSerializerTransform": "function",
+      "code": "function () { const taskList = tasks(); this.tell(\"ID                         Time          Code\"); taskList.forEach( task => this.tell(`${task.id} ${task.runAt} ${task.func.toString().substring(0, 40)}`) ) }"
+    },
     "parent": "01JND0MJEHG5TJZN5P9DWYH23V"
   },
   "01JP6SKFQNTMA9BTCMDVV9NZN3": {
@@ -63,5 +67,20 @@
     "password": "test",
     "id": "01JP6SX31466DXS068R9RHW1KT",
     "parent": "01JP12YDJ1C99A16K1VB9CP29Z"
+  },
+  "tasks": {
+    "01JPGJNZMJ2Q0ACDPJB0WX35N5": {
+      "id": "01JPGJNZMJ2Q0ACDPJB0WX35N5",
+      "func": {
+        "dbSerializerTransform": "function",
+        "code": "(a, b, c) => $mel.tell(`BOOM ${a} ${b} ${c}`)"
+      },
+      "runAt": 1742165764339,
+      "args": [
+        1,
+        2,
+        3
+      ]
+    }
   }
 }

--- a/server/test.db
+++ b/server/test.db
@@ -50,7 +50,7 @@
     },
     "command_tasks": {
       "dbSerializerTransform": "function",
-      "code": "function () { const taskList = tasks(); this.tell(\"ID                         Time          Code\"); taskList.forEach( task => this.tell(`${task.id} ${task.runAt} ${task.func.toString().substring(0, 40)}`) ) }"
+      "code": "function () { const taskList = tasks(); this.tell(\"ID                         Time          Code\"); taskList.forEach( task => { const time = `${task.interval ? '@ ' : ''}${task.runAt || task.interval}`; this.tell(`${task.id} ${time.padEnd(13)} ${task.func.toString().substring(0, 60)}` ) } ) }"
     },
     "parent": "01JND0MJEHG5TJZN5P9DWYH23V"
   },
@@ -69,13 +69,24 @@
     "parent": "01JP12YDJ1C99A16K1VB9CP29Z"
   },
   "tasks": {
-    "01JPGJNZMJ2Q0ACDPJB0WX35N5": {
-      "id": "01JPGJNZMJ2Q0ACDPJB0WX35N5",
+    "01JPGMG31TPWRVYBZ2036TC4FF": {
+      "id": "01JPGMG31TPWRVYBZ2036TC4FF",
+      "func": {
+        "dbSerializerTransform": "function",
+        "code": "(x) => $mel.tell(`${new Date()} -- ${x}`)"
+      },
+      "interval": 60000,
+      "args": [
+        "ding"
+      ]
+    },
+    "01JPGN0PXJZKS4Y2DDF02AQ8JN": {
+      "id": "01JPGN0PXJZKS4Y2DDF02AQ8JN",
       "func": {
         "dbSerializerTransform": "function",
         "code": "(a, b, c) => $mel.tell(`BOOM ${a} ${b} ${c}`)"
       },
-      "runAt": 1742165764339,
+      "runAt": 1742168213011,
       "args": [
         1,
         2,


### PR DESCRIPTION
This is a pretty simple mechanism to persist tasks across reboots.  Essentially we're putting a wrapper around `setTimeout` and `setInterval` that track the tasks, and some code in the `loadDatabase` process to restore the tasks when we load a database.  `scheduleTask` and `scheduleTaskInterval` accept the same args you'd supply to `setTimeout` or `setInterval`, but we do some checking to make sure we can serialize the functions that get passed in.

I also added a `tasks` primitive and a `tasks` command on `$superUser` that will list all the tasks we're tracking.

```
> tasks
< ID                         Time          Code
< 01JPGMG31TPWRVYBZ2036TC4FF @ 60000       (x) => $mel.tell(`${new Date()} -- ${x}`)
< Sun Mar 16 2025 16:35:48 GMT-0700 (Pacific Daylight Time) -- ding
> ; scheduleTask((a, b, c) => $mel.tell(`BOOM ${a} ${b} ${c}`), 60000, 1, 2, 3)
< 01JPGN0PXJZKS4Y2DDF02AQ8JN
< Sun Mar 16 2025 16:36:48 GMT-0700 (Pacific Daylight Time) -- ding
< BOOM 1 2 3
> ; clearTask('01JPGMG31TPWRVYBZ2036TC4FF')
< true
```
