### PR TITLE
Rework ancestry to use props

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -91,16 +91,6 @@ export function changeParent(obj, newParent) {
     newParent.children.add(obj)
 }
 
-// This function will not be used unless we think something terrible has happened.  Parent will normally be looked
-// up via the .parent property on DB objects.
-export function findParent(obj) {
-    if (!(obj instanceof DatabaseObject))
-        throw new TypeError('Not a database object')
-    const parent = Object.getPrototypeOf(obj)
-    // We don't want to expose anything above the root object, so we check for an id to confirm we're still in the DB
-    return parent.id ? parent : null
-}
-
 const dbDataFile = process.argv[2]
 
 export function loadDatabase() {

--- a/server/index.js
+++ b/server/index.js
@@ -13,3 +13,6 @@ global.telnetListener = new TelnetListener(6970)
 // Prevent server death for unhandled sync or async errors
 process.on('uncaughtException', (err) => console.error('Unhandled exception:', err))
 process.on('unhandledRejection', (reason, promise) => console.error('Unhandled Rejection at:', promise, 'reason:', reason))
+
+// Convenience hacks
+Set.prototype.toString = function () { return `Set ${Array.from(this)}`}

--- a/server/parser.js
+++ b/server/parser.js
@@ -43,7 +43,7 @@ function handleUnconnectedCommand(connection, command, argStr) {
     if (command.toLowerCase() === 'connect') {
         const args = argStr.split(/\s+/).filter( word => word ) // filter empty strings
         if (args.length === 2) {
-            const user = leaves($user).find( user => user.name === args[0] )
+            const user = $user.leaves().find( user => user.name === args[0] )
             if (user && user.password === args[1]) {
                 connection.user = user
                 connection.announce('*** Connected ***')

--- a/server/primitives.js
+++ b/server/primitives.js
@@ -1,19 +1,14 @@
-import { ancestors, changeParent, children, createObject, deleteObject, descendants, dumpDatabase, leaves, loadDatabase, parent } from './database.js'
+import { changeParent, createObject, deleteObject, dumpDatabase, loadDatabase } from './database.js'
 import { clearTask, scheduleTask, scheduleTaskInterval, tasks } from './tasks.js'
 import { ulid } from 'ulid'
 
 export function createPrimitives() {
-    global.ancestors = ancestors
     global.changeParent = changeParent
-    global.children = children
     global.clearTask = clearTask
     global.createObject = createObject
     global.deleteObject = deleteObject
-    global.descendants = descendants
     global.dumpDatabase = dumpDatabase
-    global.leaves = leaves
     global.loadDatabase = loadDatabase
-    global.parent = parent
     global.scheduleTask = scheduleTask
     global.scheduleTaskInterval = scheduleTaskInterval
     global.tasks = tasks

--- a/server/test.db.json
+++ b/server/test.db.json
@@ -4,7 +4,8 @@
     "user": "01JND0MJEHG5TJZN5P9DWYH23V",
     "mel": "01JNYBK7GXM1YYER29VVARR09Y",
     "superUser": "01JP12YDJ1C99A16K1VB9CP29Z",
-    "dan": "01JP6SX31466DXS068R9RHW1KT"
+    "dan": "01JP6SX31466DXS068R9RHW1KT",
+    "bob": "01JP6SKFQNTMA9BTCMDVV9NZN3"
   },
   "01JNY5TTYGCM2G14AWV5V0TGXA": {
     "dbSerializerTransform": "dbObject",
@@ -13,9 +14,15 @@
       "dbSerializerTransform": "function",
       "code": "function test() { return this }"
     },
-    "toString": {
-      "dbSerializerTransform": "function",
-      "code": "function () { return `${this.name ?? 'Unnamed' } (${this.id})` }"
+    "parent": null,
+    "children": {
+      "dbSerializerTransform": "set",
+      "values": [
+        {
+          "dbSerializerTransform": "ref",
+          "id": "01JND0MJEHG5TJZN5P9DWYH23V"
+        }
+      ]
     },
     "name": "Root Object"
   },
@@ -35,14 +42,37 @@
       "dbSerializerTransform": "function",
       "code": "function () { const user = this; connectionManager.connections.forEach( conn => user.tell(`${conn.constructor.name} ${conn.id} ${conn.user?.name ?? ''}`) ) }"
     },
-    "parent": "01JNY5TTYGCM2G14AWV5V0TGXA"
+    "parent": {
+      "dbSerializerTransform": "ref",
+      "id": "01JNY5TTYGCM2G14AWV5V0TGXA"
+    },
+    "children": {
+      "dbSerializerTransform": "set",
+      "values": [
+        {
+          "dbSerializerTransform": "ref",
+          "id": "01JP12YDJ1C99A16K1VB9CP29Z"
+        },
+        {
+          "dbSerializerTransform": "ref",
+          "id": "01JP6SKFQNTMA9BTCMDVV9NZN3"
+        }
+      ]
+    }
   },
   "01JNYBK7GXM1YYER29VVARR09Y": {
     "dbSerializerTransform": "dbObject",
     "name": "Mel",
     "id": "01JNYBK7GXM1YYER29VVARR09Y",
     "password": "test",
-    "parent": "01JP12YDJ1C99A16K1VB9CP29Z"
+    "parent": {
+      "dbSerializerTransform": "ref",
+      "id": "01JP12YDJ1C99A16K1VB9CP29Z"
+    },
+    "children": {
+      "dbSerializerTransform": "set",
+      "values": []
+    }
   },
   "01JP12YDJ1C99A16K1VB9CP29Z": {
     "dbSerializerTransform": "dbObject",
@@ -56,21 +86,51 @@
       "dbSerializerTransform": "function",
       "code": "function () { const taskList = tasks(); this.tell(\"ID                         Time          Code\"); taskList.forEach( task => { const time = `${task.interval ? '@ ' : ''}${task.runAt || task.interval}`; this.tell(`${task.id} ${time.padEnd(13)} ${task.func.toString().substring(0, 60)}` ) } ) }"
     },
-    "parent": "01JND0MJEHG5TJZN5P9DWYH23V"
+    "parent": {
+      "dbSerializerTransform": "ref",
+      "id": "01JND0MJEHG5TJZN5P9DWYH23V"
+    },
+    "children": {
+      "dbSerializerTransform": "set",
+      "values": [
+        {
+          "dbSerializerTransform": "ref",
+          "id": "01JNYBK7GXM1YYER29VVARR09Y"
+        },
+        {
+          "dbSerializerTransform": "ref",
+          "id": "01JP6SX31466DXS068R9RHW1KT"
+        }
+      ]
+    }
   },
   "01JP6SKFQNTMA9BTCMDVV9NZN3": {
     "dbSerializerTransform": "dbObject",
     "name": "Bob",
     "password": "test",
     "id": "01JP6SKFQNTMA9BTCMDVV9NZN3",
-    "parent": "01JND0MJEHG5TJZN5P9DWYH23V"
+    "parent": {
+      "dbSerializerTransform": "ref",
+      "id": "01JND0MJEHG5TJZN5P9DWYH23V"
+    },
+    "children": {
+      "dbSerializerTransform": "set",
+      "values": []
+    }
   },
   "01JP6SX31466DXS068R9RHW1KT": {
     "dbSerializerTransform": "dbObject",
     "name": "Dan",
     "password": "test",
     "id": "01JP6SX31466DXS068R9RHW1KT",
-    "parent": "01JP12YDJ1C99A16K1VB9CP29Z"
+    "parent": {
+      "dbSerializerTransform": "ref",
+      "id": "01JP12YDJ1C99A16K1VB9CP29Z"
+    },
+    "children": {
+      "dbSerializerTransform": "set",
+      "values": []
+    }
   },
   "tasks": {
     "01JPGMG31TPWRVYBZ2036TC4FF": {


### PR DESCRIPTION
This PR replaces the expensive traversal of the whole DB to lookup children with a system that tracks parents and children via simple props on DB objects.  There is nothing stopping anyone from manually overwriting the props, so it opens up more room for error when working with inheritance, but we are a high-trust society, and this keeps things pretty simple.  And being able to get kids quickly in a big DB is a must, so this seems like the right thing to do.

One thing I debated was whether I should move the `changeParent` primitive to DBObject, along with the `ancestors`, `descendants`, and `leaves`, instead of keeping it as a primitive.  Or moving that logic into a setter for the `.parent` property.  But I felt like that would be inviting confusion, since then you might expect you could write directly to the `.children` property and expect that to work too.  I mean, I guess technically it _could_, but that would add some significant complexity, and then we'd need backing props that were named differently and those would still be accessible.  If you have any strong opinions or thoughts about any of that let me know.

Another big part of this PR is the handling of Sets on DB objects.  I wanted the `children` prop to be a Set so there's less chance of things getting messed up and we can easily remove them.  So I had to add serialization code to handle Sets.